### PR TITLE
error-dialogs: Fix the default height

### DIFF
--- a/gtk/gtkbuilder/dialog_download_error.ui
+++ b/gtk/gtkbuilder/dialog_download_error.ui
@@ -1,10 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.22.1 -->
 <!--*- mode: xml -*-->
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="dialog_download_error">
-    <property name="visible">False</property>
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="modal">True</property>
@@ -12,6 +11,9 @@
     <property name="default_width">500</property>
     <property name="default_height">350</property>
     <property name="type_hint">dialog</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="visible">True</property>
@@ -82,6 +84,7 @@ The version of the package that you want to install might be no longer available
                     <property name="use_markup">True</property>
                     <property name="wrap">True</property>
                     <property name="selectable">True</property>
+                    <property name="width_chars">40</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>

--- a/gtk/gtkbuilder/dialog_unmet.ui
+++ b/gtk/gtkbuilder/dialog_unmet.ui
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="dialog_unmet">
-    <property name="visible">False</property>
     <property name="can_focus">False</property>
     <property name="border_width">6</property>
     <property name="modal">True</property>
@@ -11,6 +10,9 @@
     <property name="default_width">500</property>
     <property name="default_height">350</property>
     <property name="type_hint">normal</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="visible">True</property>
@@ -49,6 +51,7 @@
           <object class="GtkBox" id="box1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="spacing">12</property>
             <child>
               <object class="GtkImage" id="image">
                 <property name="visible">True</property>
@@ -79,6 +82,7 @@
 The following packages have unresolvable dependencies. Make sure that all required repositories are added and enabled in the preferences.</property>
                     <property name="use_markup">True</property>
                     <property name="wrap">True</property>
+                    <property name="width_chars">40</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>

--- a/gtk/gtkbuilder/dialog_update_failed.ui
+++ b/gtk/gtkbuilder/dialog_update_failed.ui
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.18.3 -->
+<!-- Generated with glade 3.22.1 -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="dialog_update_failed">
-    <property name="visible">False</property>
     <property name="can_focus">False</property>
     <property name="border_width">5</property>
     <property name="modal">True</property>
@@ -11,6 +10,9 @@
     <property name="default_width">500</property>
     <property name="default_height">350</property>
     <property name="type_hint">normal</property>
+    <child>
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox" id="dialog-vbox1">
         <property name="visible">True</property>
@@ -81,6 +83,7 @@ The repository may no longer be available or could not be contacted because of n
                     <property name="use_markup">True</property>
                     <property name="wrap">True</property>
                     <property name="selectable">True</property>
+                    <property name="width_chars">40</property>
                     <property name="xalign">0</property>
                   </object>
                   <packing>


### PR DESCRIPTION
The long wrapped labels in these dialogs were forcing a very tall default
window height. Set a character width of 40 on these labels to get the height
back to a sane size.